### PR TITLE
zodの導入とzodを利用した型ガードの実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "express": "^4.18.2"
+        "express": "^4.18.2",
+        "zod": "^3.19.1"
       },
       "devDependencies": {
         "@types/express": "^4.17.14",
@@ -7412,6 +7413,14 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zod": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz",
+      "integrity": "sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   },
   "dependencies": {
@@ -12848,6 +12857,11 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zod": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz",
+      "integrity": "sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "typesync": "^0.9.2"
   },
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "zod": "^3.19.1"
   }
 }

--- a/src/features/__tests__/cat/validateCat.spec.ts
+++ b/src/features/__tests__/cat/validateCat.spec.ts
@@ -1,0 +1,96 @@
+/* eslint-disable max-lines-per-function, max-statements, no-magic-numbers */
+import { validateCat } from '../../cat';
+
+describe('src/features/cat.ts validateCat TestCases', () => {
+  const validationErrorTable = [
+    [
+      {
+        // 最小値より小さい
+        id: -1,
+        // 最小値より小さい
+        name: '',
+        // 空文字
+        breed: '',
+      },
+      [
+        {
+          name: 'id',
+          reason: 'Number must be greater than or equal to 1',
+        },
+        {
+          name: 'name',
+          reason: 'String must contain at least 1 character(s)',
+        },
+        {
+          name: 'breed',
+          reason:
+            "Invalid enum value. Expected 'ScottishFold' | 'Persian' | 'Bengal' | 'Munchkin', received ''",
+        },
+      ],
+    ],
+    [
+      {
+        // 最小値より大きい
+        id: Number.MAX_SAFE_INTEGER + 1,
+        // 最小値より大きい
+        name: 'AAAAAAAAAAAAAAAAAAAAA',
+        // 許可されていない文字列
+        breed: 'dog',
+      },
+      [
+        {
+          name: 'id',
+          reason: `Number must be less than or equal to ${Number.MAX_SAFE_INTEGER}`,
+        },
+        { name: 'name', reason: 'String must contain at most 20 character(s)' },
+        {
+          name: 'breed',
+          reason:
+            "Invalid enum value. Expected 'ScottishFold' | 'Persian' | 'Bengal' | 'Munchkin', received 'dog'",
+        },
+      ],
+    ],
+  ];
+
+  it.each(validationErrorTable)(
+    'should return a validation error. params: %s',
+    (request, expected) => {
+      const result = validateCat(request);
+
+      expect(result.isValidate).toBeFalsy();
+      expect(result.invalidParams).toStrictEqual(expected);
+    }
+  );
+
+  const passValidationTable = [
+    [
+      {
+        // 最小値ギリギリ
+        id: 1,
+        // 最小値ギリギリ
+        name: 'C',
+        //
+        breed: 'ScottishFold',
+      },
+    ],
+    [
+      {
+        // 最大値ギリギリ
+        id: Number.MAX_SAFE_INTEGER,
+        // 最大値ギリギリ
+        name: 'CCCCCCCCCCCCCCCCCCCC',
+        //
+        breed: 'Persian',
+      },
+    ],
+  ];
+
+  it.each(passValidationTable)(
+    'should not be a validation error. params: %s',
+    (request) => {
+      const expected = { isValidate: true };
+
+      expect(validateCat(request)).toStrictEqual(expected);
+    }
+  );
+});

--- a/src/features/__tests__/validator/validation.spec.ts
+++ b/src/features/__tests__/validator/validation.spec.ts
@@ -1,0 +1,123 @@
+/* eslint-disable max-lines-per-function, max-statements, no-magic-numbers */
+import { z } from 'zod';
+
+import { ValidationError } from '../../errors/ValidationError';
+import { validation, createSchemaFromType } from '../../validator';
+
+describe('src/features/validator.ts validation TestCases', () => {
+  type Email = string;
+
+  type TestSchema = {
+    count: number;
+    email: Email;
+    userName?: string;
+    color?: 'pink' | 'red';
+  };
+
+  const allParamsTable = [
+    [
+      {
+        count: -1,
+        email: '',
+        userName: '',
+        color: 'unknown',
+      },
+      [
+        { name: 'count', reason: 'Number must be greater than or equal to 1' },
+        { name: 'email', reason: 'Invalid email' },
+        {
+          name: 'userName',
+          reason: 'String must contain at least 1 character(s)',
+        },
+        { name: 'color', reason: 'Invalid input' },
+      ],
+    ],
+  ];
+
+  const testSchema = createSchemaFromType<TestSchema>()(
+    z.object({
+      count: z.number().min(1),
+      email: z.string().email(),
+      userName: z.string().min(1).optional(),
+      color: z.union([z.literal('pink'), z.literal('red')]).optional(),
+    })
+  );
+
+  it.each(allParamsTable)(
+    'should return a validation error for all parameters. params: %s',
+    (params, expected) => {
+      const result = validation(testSchema, params);
+
+      expect(result.isValidate).toBeFalsy();
+      expect(result.invalidParams).toStrictEqual(expected);
+
+      // ここから下は意味がないように見えるが、z.infer で型定義を生成出来る事を確認する意図で書いている
+      type CreatedTestSchema = z.infer<typeof testSchema>;
+
+      const sampleSchema: CreatedTestSchema = {
+        count: 1,
+        email: 'aa@aa',
+        userName: '',
+        color: 'pink',
+      };
+
+      expect(sampleSchema).toStrictEqual(sampleSchema);
+    }
+  );
+
+  const requiredParamsTable = [
+    [
+      {
+        count: -1,
+        email: '',
+      },
+      [
+        { name: 'count', reason: 'Number must be greater than or equal to 1' },
+        { name: 'email', reason: 'Invalid email' },
+      ],
+    ],
+  ];
+
+  it.each(requiredParamsTable)(
+    'should return a validation error for required parameters. params: %s',
+    (params, expected) => {
+      const result = validation(testSchema, params);
+
+      expect(result.isValidate).toBeFalsy();
+      expect(result.invalidParams).toStrictEqual(expected);
+    }
+  );
+
+  it('should not be a validation error', () => {
+    const params = {
+      count: 10,
+      email: 'kkk.kkk@exmple.com',
+      userName: 'MyName',
+      color: 'red',
+    };
+
+    const expected = { isValidate: true };
+
+    expect(validation(testSchema, params)).toStrictEqual(expected);
+  });
+
+  it('should throw an ValidationError, because parse threw an error', () => {
+    const mockSchema = {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      parse: (params: unknown) => {
+        throw new Error('mockSchema error');
+      },
+    };
+
+    const params = {
+      count: 10,
+      email: 'kkk.kkk@exmple.com',
+      userName: 'MyName',
+      color: 'red',
+    };
+
+    expect(() => validation(mockSchema, params)).toThrow(
+      new ValidationError('mockSchema error')
+    );
+  });
+});

--- a/src/features/cat.ts
+++ b/src/features/cat.ts
@@ -1,3 +1,6 @@
+import { z } from 'zod';
+import { validation, ValidationResult } from './validator';
+
 type CatId = number;
 
 type CatName = string;
@@ -11,6 +14,16 @@ type Cat = {
   readonly id: CatId;
   readonly name: CatName;
   readonly breed: CatBreed;
+};
+
+const catSchema = z.object({
+  id: z.number().min(1).max(Number.MAX_SAFE_INTEGER),
+  name: z.string().min(1).max(20),
+  breed: z.enum(catBreedList),
+});
+
+export const validateCat = (params: unknown): ValidationResult => {
+  return validation(catSchema, params);
 };
 
 const cats: Cat[] = [

--- a/src/features/cat.ts
+++ b/src/features/cat.ts
@@ -3,7 +3,9 @@ type CatId = number;
 type CatName = string;
 
 // https://u-ful.com/12448 のページから一部拝借
-type CatBreed = 'ScottishFold' | 'Persian' | 'Bengal' | 'Munchkin';
+const catBreedList = ['ScottishFold', 'Persian', 'Bengal', 'Munchkin'] as const;
+
+type CatBreed = typeof catBreedList[number];
 
 type Cat = {
   readonly id: CatId;

--- a/src/features/cat.ts
+++ b/src/features/cat.ts
@@ -26,6 +26,16 @@ export const validateCat = (params: unknown): ValidationResult => {
   return validation(catSchema, params);
 };
 
+export const isCat = (value: unknown): value is Cat => {
+  if (Object.prototype.toString.call(value) !== '[object Object]') {
+    return false;
+  }
+
+  const validationResult = validateCat(value);
+
+  return validationResult.isValidate;
+};
+
 const cats: Cat[] = [
   { id: 1, name: 'つくし', breed: 'ScottishFold' as const },
   { id: 2, name: 'モコ', breed: 'Persian' as const },

--- a/src/features/errors/ValidationError.ts
+++ b/src/features/errors/ValidationError.ts
@@ -1,0 +1,11 @@
+export class ValidationError extends Error {
+  constructor(error?: string) {
+    super(error);
+    this.name = new.target.name;
+
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}

--- a/src/features/validator.ts
+++ b/src/features/validator.ts
@@ -1,0 +1,91 @@
+import { z, ZodError } from 'zod';
+
+import { ValidationError } from './errors/ValidationError';
+
+type InvalidParam = {
+  name: string;
+  reason: string;
+};
+
+type InvalidParams = InvalidParam[];
+
+export type ValidationResult = {
+  isValidate: boolean;
+  invalidParams?: InvalidParams;
+};
+
+// eslint-disable-next-line max-statements
+const isInvalidParams = (value: unknown): value is InvalidParams => {
+  if (Array.isArray(value)) {
+    // eslint-disable-next-line no-magic-numbers
+    if (value.length === 0) {
+      return false;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const object = value[0];
+    if (Object.prototype.toString.call(object) !== '[object Object]') {
+      return false;
+    }
+
+    const invalidParam = object as InvalidParam;
+    if (!Object.hasOwn(invalidParam, 'name')) {
+      return false;
+    }
+
+    return Object.hasOwn(invalidParam, 'reason');
+  }
+
+  return false;
+};
+
+const isZodError = (error: unknown): error is ZodError => {
+  if (error instanceof ZodError) {
+    return true;
+  }
+
+  if (error instanceof Error) {
+    if (error.name === 'ZodError') {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+export const createSchemaFromType =
+  <T>() =>
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+  <S extends z.ZodType<T, any, any>>(arg: S) =>
+    arg;
+
+type ValidationSchema = {
+  parse: (params: unknown) => unknown;
+};
+
+export const validation = (
+  schema: ValidationSchema,
+  params: unknown
+): ValidationResult => {
+  try {
+    schema.parse(params);
+
+    return { isValidate: true };
+  } catch (error) {
+    if (isZodError(error)) {
+      const invalidParams = error.errors.map((value) => ({
+        // eslint-disable-next-line no-magic-numbers
+        name: value.path[0],
+        reason: value.message,
+      }));
+
+      if (isInvalidParams(invalidParams)) {
+        return { isValidate: false, invalidParams };
+      }
+    }
+
+    throw error instanceof Error
+      ? new ValidationError(error.message)
+      : new ValidationError('failed to validation');
+  }
+};


### PR DESCRIPTION
# 内容

zodを利用したバリデーション関数を実装。

`validation` という汎用的な関数を実装。

エラーの形式に関しては https://www.rfc-editor.org/rfc/rfc7807 の `invalid-params` を参考にしている。

`validateCat` と `isCat` に関しては `validation` を元に実装している。