### PR TITLE
never型を利用した網羅性チェックのサンプルコードを追加

### DIFF
--- a/src/features/__tests__/cat/convertBreedIntoJapanese.spec.ts
+++ b/src/features/__tests__/cat/convertBreedIntoJapanese.spec.ts
@@ -1,0 +1,19 @@
+import { convertBreedIntoJapanese } from '../../cat';
+
+describe('src/features/cat.ts convertBreedIntoJapanese TestCases', () => {
+  const table = [
+    ['ScottishFold', 'スコティッシュフォールド'],
+    ['Persian', 'ペルシャ猫'],
+    ['Bengal', 'ベンガル'],
+    ['Munchkin', 'マンチカン'],
+  ] as const;
+
+  it.each(table)(
+    'should return the japanese breed. params: %s',
+    (request, expected) => {
+      const result = convertBreedIntoJapanese(request);
+
+      expect(result).toStrictEqual(expected);
+    }
+  );
+});

--- a/src/features/cat.ts
+++ b/src/features/cat.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { ExhaustiveError } from './errors/ExhaustiveError';
 import { validation, ValidationResult } from './validator';
 
 type CatId = number;
@@ -14,6 +15,32 @@ type Cat = {
   readonly id: CatId;
   readonly name: CatName;
   readonly breed: CatBreed;
+};
+
+const japaneseCatBreedList = [
+  'スコティッシュフォールド',
+  'ペルシャ猫',
+  'ベンガル',
+  'マンチカン',
+] as const;
+
+type JapaneseCatBreed = typeof japaneseCatBreedList[number];
+
+export const convertBreedIntoJapanese = (
+  catBreed: CatBreed
+): JapaneseCatBreed => {
+  switch (catBreed) {
+    case 'ScottishFold':
+      return 'スコティッシュフォールド';
+    case 'Persian':
+      return 'ペルシャ猫';
+    case 'Bengal':
+      return 'ベンガル';
+    case 'Munchkin':
+      return 'マンチカン';
+    default:
+      throw new ExhaustiveError(catBreed);
+  }
 };
 
 const catSchema = z.object({

--- a/src/features/errors/ExhaustiveError.ts
+++ b/src/features/errors/ExhaustiveError.ts
@@ -1,0 +1,6 @@
+export class ExhaustiveError extends Error {
+  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+  constructor(value: never, message = `Unsupported type: ${value}`) {
+    super(message);
+  }
+}


### PR DESCRIPTION
# 内容

日本語のねこの種類を返す `convertBreedIntoJapanese` を実装。

さらに網羅性チェックが行われていない場合に利用する `ExhaustiveError` を実装。