### PR TITLE
fetchJson関数を型安全な形に改善

### DIFF
--- a/src/features/__tests__/fetcher/fetchJson.spec.ts
+++ b/src/features/__tests__/fetcher/fetchJson.spec.ts
@@ -18,13 +18,13 @@ const mockServer = setupServer(...mockHandlers);
 
 // GitHubのユーザー情報取得APIの型定義。全ての型定義をするのは手間なので必要な値にだけ絞って型定義だけ行っています
 type FetchGitHubUserResponseBody = {
-  login: string;
-  id: number;
-  url: `https://api.github.com/users/${string}`;
-  name: string;
-  company: string;
-  blog: string;
-  location: string;
+  readonly login: string;
+  readonly id: number;
+  readonly url: `https://api.github.com/users/${string}`;
+  readonly name: string;
+  readonly company: string;
+  readonly blog: string;
+  readonly location: string;
 };
 
 const fetchGitHubUserSchema = z.object({

--- a/src/features/__tests__/fetcher/fetchJson.spec.ts
+++ b/src/features/__tests__/fetcher/fetchJson.spec.ts
@@ -36,7 +36,7 @@ const fetchGitHubUserSchema = z.object({
   location: z.string().min(1).max(20),
 });
 
-const isFetchGitHubUserSchema = (
+const isFetchGitHubUserResponseBody = (
   value: unknown
 ): value is FetchGitHubUserResponseBody => {
   return validation(fetchGitHubUserSchema, value).isValidate;
@@ -97,7 +97,7 @@ describe('src/features/fetcher.ts fetchJson TestCases', () => {
 
     const result = await fetchJson<FetchGitHubUserResponseBody>(
       'https://api.github.com/users/keitakn',
-      isFetchGitHubUserSchema
+      isFetchGitHubUserResponseBody
     );
 
     expect(result).toStrictEqual(expected);
@@ -107,7 +107,7 @@ describe('src/features/fetcher.ts fetchJson TestCases', () => {
     mockServer.use(rest.get(testUrl, mockInternalServerError));
 
     await expect(
-      fetchJson(testUrl, isFetchGitHubUserSchema)
+      fetchJson(testUrl, isFetchGitHubUserResponseBody)
     ).rejects.toStrictEqual(
       new Error(
         'Internal Server Error src/features/fetcher.ts failed to fetchJson'

--- a/src/features/__tests__/fetcher/fetchJson.spec.ts
+++ b/src/features/__tests__/fetcher/fetchJson.spec.ts
@@ -16,7 +16,7 @@ const mockHandlers = [rest.get(testUrl, mockFetchUser)];
 
 const mockServer = setupServer(...mockHandlers);
 
-// 全ての型定義をするのは手間なので必要な値にだけ絞って型定義だけ行っています
+// GitHubのユーザー情報取得APIの型定義。全ての型定義をするのは手間なので必要な値にだけ絞って型定義だけ行っています
 type FetchGitHubUserResponseBody = {
   login: string;
   id: number;

--- a/src/features/fetcher.ts
+++ b/src/features/fetcher.ts
@@ -18,7 +18,7 @@ export const fetchJson = async <T>(
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const responseBody = await response.json();
   if (!typeGuardFunction(responseBody)) {
-    throw new Error('src/features/fetcher.ts responseBody type si invalid');
+    throw new Error('src/features/fetcher.ts responseBody type is invalid');
   }
 
   return responseBody;

--- a/src/features/fetcher.ts
+++ b/src/features/fetcher.ts
@@ -1,4 +1,9 @@
-export const fetchJson = async <T>(url: string): Promise<T> => {
+export type TypeGuardFunction<T> = (value: unknown) => value is T;
+
+export const fetchJson = async <T>(
+  url: string,
+  typeGuardFunction: TypeGuardFunction<T>
+): Promise<T> => {
   const options: RequestInit = {
     method: 'GET',
   };
@@ -10,5 +15,11 @@ export const fetchJson = async <T>(url: string): Promise<T> => {
     );
   }
 
-  return (await response.json()) as T;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const responseBody = await response.json();
+  if (!typeGuardFunction(responseBody)) {
+    throw new Error('src/features/fetcher.ts responseBody type si invalid');
+  }
+
+  return responseBody;
 };


### PR DESCRIPTION
# 内容

`fetchJson` の第2引数に型ガード関数を受け取るように変更。